### PR TITLE
Updated code coverage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,13 +11,11 @@ dependencies:
     - pip install ansible
     - pip install --upgrade setuptools
     - npm install npm@latest -g
-    - npm install coveralls
 
 test:
   override:
     - npm test
   post:
-    - coveralls
     - mkdir $CIRCLE_ARTIFACTS/coveralls
     - mv coverage/html/*.* $CIRCLE_ARTIFACTS/coveralls
 

--- a/circle.yml
+++ b/circle.yml
@@ -11,11 +11,13 @@ dependencies:
     - pip install ansible
     - pip install --upgrade setuptools
     - npm install npm@latest -g
+    - npm install coveralls
 
 test:
   override:
     - npm test
   post:
+    - coveralls
     - mkdir $CIRCLE_ARTIFACTS/coveralls
     - mv coverage/html/*.* $CIRCLE_ARTIFACTS/coveralls
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
             'tests/tests.webpack.js'
         ],
         preprocessors: {
-            'tests/tests.webpack.js': ['webpack', 'sourcemap']
+            'tests/tests.webpack.js': ['webpack', 'sourcemap', 'coverage']
         },
         webpack: {
             devtool: 'inline-source-map',
@@ -67,7 +67,7 @@ module.exports = function(config) {
             reporters: [
                 // reporters not supporting the `file` property
                 { type: 'html', subdir: 'html' },
-                { type: 'lcov' },
+                { type: 'lcov', subdir: '.', file: 'lcov.info'},
                 // reporters supporting the `file` property, use `subdir` to directly
                 // output them in the `dir` directory
                 { type: 'cobertura', subdir: '.', file: 'cobertura.txt' },


### PR DESCRIPTION
### Before submitting a pull request, make sure you have:
- [X] Read the [README](https://github.com/TSAP-Laval/acquisition-frontend/blob/master/README.md)
- [X] [Searched](https://github.com/TSAP-Laval/acquisition-frontend/search?type=Issues) the bugtracker for similar issues including **closed** ones
- [X] Reviewed the sample code in [tests](https://github.com/TSAP-Laval/acquisition-frontend/tree/master/tests)

### Purpose of your pull request?
- [X] Bug fix (encountered problems/errors)
- [ ] Feature (request of a new functionality)
- [X] Enhancement
- [ ] Other

---

Correction du code coverage... Désormais, nous aurons une idée de 'coverage' de nos tests front-end. Pour plus de détails vous pouvez aller voir sur coveralls.io le fonctionnement et résultat d'un code coverage... En d'autres mots, ca permet environ de voir à quel point nos tests couvrent notre code, souvent sous forme de pourcentage.